### PR TITLE
dagrin用リージョンをハードコードする

### DIFF
--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -195,17 +195,19 @@ func (g *S3) new(creds madmin.Credentials, transport http.RoundTripper) (*miniog
 	}
 
 	optionsStaticCreds := &miniogo.Options{
-		Creds:        credentials.NewStaticV4(creds.AccessKey, creds.SecretKey, creds.SessionToken),
-		Secure:       secure,
-		Region:       s3utils.GetRegionFromURL(*u),
+		Creds:  credentials.NewStaticV4(creds.AccessKey, creds.SecretKey, creds.SessionToken),
+		Secure: secure,
+		Region: "ap1",
+		// Region:       s3utils.GetRegionFromURL(*u),
 		BucketLookup: miniogo.BucketLookupAuto,
 		Transport:    transport,
 	}
 
 	optionsChainCreds := &miniogo.Options{
-		Creds:        chainCreds,
-		Secure:       secure,
-		Region:       s3utils.GetRegionFromURL(*u),
+		Creds:  chainCreds,
+		Secure: secure,
+		Region: "ap1",
+		// Region:       s3utils.GetRegionFromURL(*u),
 		BucketLookup: miniogo.BucketLookupAuto,
 		Transport:    transport,
 	}


### PR DESCRIPTION
## Description

オリジナルの実装ではS3のvirtual hosting styleでリージョンを取得するが、Dagrinはドメイン名に関係なくリージョンが"ap1"であるためハードコードする。本来はdagrin driverとして実装すべきだろうが、もう少しDagrin用の修正がまとまってから対応する。

## Motivation and Context

そのままではDagrinでは利用できないため。

## How to test this PR?

```
minio gateway s3 https://storage-dag.iijgio.com
mc ls local
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
